### PR TITLE
[CARESERV-928] Renaming Entity in gqlgen to avoid type name conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,27 @@
+# Grand Rounds Fork of gqlgen
+
+This fork was created by:
+
+1. Forking the repository
+1. Resetting master of the fork to the tagged commit of the last stable release
+   of gqlgen. At the time of writing this, it's tag v0.13.0 and commit 07c1f93.
+1. Pushing -f to reset master of this fork the above commit.
+1. Creating a branch in this repo and applying the desired patch.
+1. Runing `go generate ./...` in the root of this repository.
+1. Opening a pull request of the patch we've applied, to this fork
+1. Testing the forked code in the downstream repo (bobs) using `replace` in
+   `go.mod`.
+1. Merging the patch into the master branch of this fork.
+1. Updating downstream consumers to use the master branch of this fork using
+   `replace` in `go.mod`
+
+Note that means the master branch of this fork diverges from the official
+repository. To update this fork to the latest version of gqlgen:
+
+1. Merge the latest version tagged commit of upstream into master of this fork.
+   **Don't** merge in the master branch of the main repository, just the commit
+   of the next tagged version.
+
 # gqlgen [![Continuous Integration](https://github.com/99designs/gqlgen/workflows/Continuous%20Integration/badge.svg)](https://github.com/99designs/gqlgen/actions) [![Read the Docs](https://badgen.net/badge/docs/available/green)](http://gqlgen.com/) [![GoDoc](https://godoc.org/github.com/99designs/gqlgen?status.svg)](https://godoc.org/github.com/99designs/gqlgen)
 
 ![gqlgen](https://user-images.githubusercontent.com/46195831/89802919-0bb8ef00-db2a-11ea-8ba4-88e7a58b2fd2.png)
@@ -82,6 +106,25 @@ After doing either of the above and running generate we will need to provide a r
 func (r *userResolver) Friends(ctx context.Context, obj *User) ([]*User, error) {
   // select * from user where friendid = obj.ID
   return friends,  nil
+}
+```
+
+You can also use inline config with directives to achieve the same result
+
+```graphql
+directive @goModel(model: String, models: [String!]) on OBJECT
+    | INPUT_OBJECT
+    | SCALAR
+    | ENUM
+    | INTERFACE
+    | UNION
+
+directive @goField(forceResolver: Boolean, name: String) on INPUT_FIELD_DEFINITION
+    | FIELD_DEFINITION
+
+type User @goModel(model: "github.com/you/pkg/model.User") {
+    id: ID!         @goField(name: "todoId")
+    friends: [User!]!   @goField(forceResolver: true)
 }
 ```
 

--- a/codegen/templates/templates.go
+++ b/codegen/templates/templates.go
@@ -282,10 +282,25 @@ func Call(p *types.Func) string {
 	return pkg + p.Name()
 }
 
+// Federated graphs have the types _Entity and _Service. With default Go struct
+// name generation, those become `Service`, which can conflict with users
+// of this library who have their own `type Service`. Special case handle the
+// federated entity names
+var internalNames = map[string]string{
+	"_Entity":  "GqlgenEntity",
+	"_Service": "GqlgenService",
+}
+
 func ToGo(name string) string {
 	if name == "_" {
 		return "_"
 	}
+
+	internalName, hasInternalName := internalNames[name]
+	if hasInternalName {
+		return internalName
+	}
+
 	runes := make([]rune, 0, len(name))
 
 	wordWalker(name, func(info *wordInfo) {

--- a/codegen/templates/templates_test.go
+++ b/codegen/templates/templates_test.go
@@ -38,6 +38,11 @@ func TestToGo(t *testing.T) {
 	require.Equal(t, "RelatedUrls", ToGo("RelatedUrls"))
 	require.Equal(t, "ITicket", ToGo("ITicket"))
 	require.Equal(t, "FooTicket", ToGo("fooTicket"))
+
+	require.Equal(t, "GqlgenEntity", ToGo("_Entity"))
+	require.Equal(t, "GqlgenService", ToGo("_Service"))
+	require.Equal(t, "Entity", ToGo("Entity"))
+	require.Equal(t, "Service", ToGo("Service"))
 }
 
 func TestToGoPrivate(t *testing.T) {

--- a/example/federation/accounts/graph/generated/federation.go
+++ b/example/federation/accounts/graph/generated/federation.go
@@ -11,9 +11,9 @@ import (
 	"github.com/99designs/gqlgen/plugin/federation/fedruntime"
 )
 
-func (ec *executionContext) __resolve__service(ctx context.Context) (fedruntime.Service, error) {
+func (ec *executionContext) __resolve__service(ctx context.Context) (fedruntime.GqlgenService, error) {
 	if ec.DisableIntrospection {
-		return fedruntime.Service{}, errors.New("federated introspection disabled")
+		return fedruntime.GqlgenService{}, errors.New("federated introspection disabled")
 	}
 
 	var sdl []string
@@ -25,13 +25,13 @@ func (ec *executionContext) __resolve__service(ctx context.Context) (fedruntime.
 		sdl = append(sdl, src.Input)
 	}
 
-	return fedruntime.Service{
+	return fedruntime.GqlgenService{
 		SDL: strings.Join(sdl, "\n"),
 	}, nil
 }
 
-func (ec *executionContext) __resolve_entities(ctx context.Context, representations []map[string]interface{}) ([]fedruntime.Entity, error) {
-	list := []fedruntime.Entity{}
+func (ec *executionContext) __resolve_entities(ctx context.Context, representations []map[string]interface{}) ([]fedruntime.GqlgenEntity, error) {
+	list := []fedruntime.GqlgenEntity{}
 	for _, rep := range representations {
 		typeName, ok := rep["__typename"].(string)
 		if !ok {

--- a/example/federation/accounts/graph/generated/generated.go
+++ b/example/federation/accounts/graph/generated/generated.go
@@ -60,7 +60,7 @@ type ComplexityRoot struct {
 		Username func(childComplexity int) int
 	}
 
-	Service struct {
+	GqlgenService struct {
 		SDL func(childComplexity int) int
 	}
 }
@@ -140,11 +140,11 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		return e.complexity.User.Username(childComplexity), true
 
 	case "_Service.sdl":
-		if e.complexity.Service.SDL == nil {
+		if e.complexity.GqlgenService.SDL == nil {
 			break
 		}
 
-		return e.complexity.Service.SDL(childComplexity), true
+		return e.complexity.GqlgenService.SDL(childComplexity), true
 
 	}
 	return 0, false
@@ -435,9 +435,9 @@ func (ec *executionContext) _Query__entities(ctx context.Context, field graphql.
 		}
 		return graphql.Null
 	}
-	res := resTmp.([]fedruntime.Entity)
+	res := resTmp.([]fedruntime.GqlgenEntity)
 	fc.Result = res
-	return ec.marshalN_Entity2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋfedruntimeᚐEntity(ctx, field.Selections, res)
+	return ec.marshalN_Entity2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋfedruntimeᚐGqlgenEntity(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Query__service(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
@@ -470,9 +470,9 @@ func (ec *executionContext) _Query__service(ctx context.Context, field graphql.C
 		}
 		return graphql.Null
 	}
-	res := resTmp.(fedruntime.Service)
+	res := resTmp.(fedruntime.GqlgenService)
 	fc.Result = res
-	return ec.marshalN_Service2githubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋfedruntimeᚐService(ctx, field.Selections, res)
+	return ec.marshalN_Service2githubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋfedruntimeᚐGqlgenService(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Query___type(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
@@ -616,7 +616,7 @@ func (ec *executionContext) _User_username(ctx context.Context, field graphql.Co
 	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) __Service_sdl(ctx context.Context, field graphql.CollectedField, obj *fedruntime.Service) (ret graphql.Marshaler) {
+func (ec *executionContext) __Service_sdl(ctx context.Context, field graphql.CollectedField, obj *fedruntime.GqlgenService) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
 			ec.Error(ctx, ec.Recover(ctx, r))
@@ -1739,7 +1739,7 @@ func (ec *executionContext) ___Type_ofType(ctx context.Context, field graphql.Co
 
 // region    ************************** interface.gotpl ***************************
 
-func (ec *executionContext) __Entity(ctx context.Context, sel ast.SelectionSet, obj fedruntime.Entity) graphql.Marshaler {
+func (ec *executionContext) __Entity(ctx context.Context, sel ast.SelectionSet, obj fedruntime.GqlgenEntity) graphql.Marshaler {
 	switch obj := (obj).(type) {
 	case nil:
 		return graphql.Null
@@ -1902,7 +1902,7 @@ func (ec *executionContext) _User(ctx context.Context, sel ast.SelectionSet, obj
 
 var _ServiceImplementors = []string{"_Service"}
 
-func (ec *executionContext) __Service(ctx context.Context, sel ast.SelectionSet, obj *fedruntime.Service) graphql.Marshaler {
+func (ec *executionContext) __Service(ctx context.Context, sel ast.SelectionSet, obj *fedruntime.GqlgenService) graphql.Marshaler {
 	fields := graphql.CollectFields(ec.OperationContext, sel, _ServiceImplementors)
 
 	out := graphql.NewFieldSet(fields)
@@ -2279,7 +2279,7 @@ func (ec *executionContext) marshalN_Any2ᚕmapᚄ(ctx context.Context, sel ast.
 	return ret
 }
 
-func (ec *executionContext) marshalN_Entity2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋfedruntimeᚐEntity(ctx context.Context, sel ast.SelectionSet, v []fedruntime.Entity) graphql.Marshaler {
+func (ec *executionContext) marshalN_Entity2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋfedruntimeᚐGqlgenEntity(ctx context.Context, sel ast.SelectionSet, v []fedruntime.GqlgenEntity) graphql.Marshaler {
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -2303,7 +2303,7 @@ func (ec *executionContext) marshalN_Entity2ᚕgithubᚗcomᚋ99designsᚋgqlgen
 			if !isLen1 {
 				defer wg.Done()
 			}
-			ret[i] = ec.marshalO_Entity2githubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋfedruntimeᚐEntity(ctx, sel, v[i])
+			ret[i] = ec.marshalO_Entity2githubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋfedruntimeᚐGqlgenEntity(ctx, sel, v[i])
 		}
 		if isLen1 {
 			f(i)
@@ -2331,7 +2331,7 @@ func (ec *executionContext) marshalN_FieldSet2string(ctx context.Context, sel as
 	return res
 }
 
-func (ec *executionContext) marshalN_Service2githubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋfedruntimeᚐService(ctx context.Context, sel ast.SelectionSet, v fedruntime.Service) graphql.Marshaler {
+func (ec *executionContext) marshalN_Service2githubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋfedruntimeᚐGqlgenService(ctx context.Context, sel ast.SelectionSet, v fedruntime.GqlgenService) graphql.Marshaler {
 	return ec.__Service(ctx, sel, &v)
 }
 
@@ -2619,7 +2619,7 @@ func (ec *executionContext) marshalOUser2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ
 	return ec._User(ctx, sel, v)
 }
 
-func (ec *executionContext) marshalO_Entity2githubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋfedruntimeᚐEntity(ctx context.Context, sel ast.SelectionSet, v fedruntime.Entity) graphql.Marshaler {
+func (ec *executionContext) marshalO_Entity2githubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋfedruntimeᚐGqlgenEntity(ctx context.Context, sel ast.SelectionSet, v fedruntime.GqlgenEntity) graphql.Marshaler {
 	if v == nil {
 		return graphql.Null
 	}

--- a/example/federation/accounts/graph/model/models_gen.go
+++ b/example/federation/accounts/graph/model/models_gen.go
@@ -7,4 +7,4 @@ type User struct {
 	Username string `json:"username"`
 }
 
-func (User) IsEntity() {}
+func (User) IsGqlgenEntity() {}

--- a/example/federation/products/graph/generated/federation.go
+++ b/example/federation/products/graph/generated/federation.go
@@ -11,9 +11,9 @@ import (
 	"github.com/99designs/gqlgen/plugin/federation/fedruntime"
 )
 
-func (ec *executionContext) __resolve__service(ctx context.Context) (fedruntime.Service, error) {
+func (ec *executionContext) __resolve__service(ctx context.Context) (fedruntime.GqlgenService, error) {
 	if ec.DisableIntrospection {
-		return fedruntime.Service{}, errors.New("federated introspection disabled")
+		return fedruntime.GqlgenService{}, errors.New("federated introspection disabled")
 	}
 
 	var sdl []string
@@ -25,13 +25,13 @@ func (ec *executionContext) __resolve__service(ctx context.Context) (fedruntime.
 		sdl = append(sdl, src.Input)
 	}
 
-	return fedruntime.Service{
+	return fedruntime.GqlgenService{
 		SDL: strings.Join(sdl, "\n"),
 	}, nil
 }
 
-func (ec *executionContext) __resolve_entities(ctx context.Context, representations []map[string]interface{}) ([]fedruntime.Entity, error) {
-	list := []fedruntime.Entity{}
+func (ec *executionContext) __resolve_entities(ctx context.Context, representations []map[string]interface{}) ([]fedruntime.GqlgenEntity, error) {
+	list := []fedruntime.GqlgenEntity{}
 	for _, rep := range representations {
 		typeName, ok := rep["__typename"].(string)
 		if !ok {

--- a/example/federation/products/graph/generated/generated.go
+++ b/example/federation/products/graph/generated/generated.go
@@ -61,7 +61,7 @@ type ComplexityRoot struct {
 		__resolve_entities func(childComplexity int, representations []map[string]interface{}) int
 	}
 
-	Service struct {
+	GqlgenService struct {
 		SDL func(childComplexity int) int
 	}
 }
@@ -153,11 +153,11 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		return e.complexity.Query.__resolve_entities(childComplexity, args["representations"].([]map[string]interface{})), true
 
 	case "_Service.sdl":
-		if e.complexity.Service.SDL == nil {
+		if e.complexity.GqlgenService.SDL == nil {
 			break
 		}
 
-		return e.complexity.Service.SDL(childComplexity), true
+		return e.complexity.GqlgenService.SDL(childComplexity), true
 
 	}
 	return 0, false
@@ -576,9 +576,9 @@ func (ec *executionContext) _Query__entities(ctx context.Context, field graphql.
 		}
 		return graphql.Null
 	}
-	res := resTmp.([]fedruntime.Entity)
+	res := resTmp.([]fedruntime.GqlgenEntity)
 	fc.Result = res
-	return ec.marshalN_Entity2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋfedruntimeᚐEntity(ctx, field.Selections, res)
+	return ec.marshalN_Entity2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋfedruntimeᚐGqlgenEntity(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Query__service(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
@@ -611,9 +611,9 @@ func (ec *executionContext) _Query__service(ctx context.Context, field graphql.C
 		}
 		return graphql.Null
 	}
-	res := resTmp.(fedruntime.Service)
+	res := resTmp.(fedruntime.GqlgenService)
 	fc.Result = res
-	return ec.marshalN_Service2githubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋfedruntimeᚐService(ctx, field.Selections, res)
+	return ec.marshalN_Service2githubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋfedruntimeᚐGqlgenService(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Query___type(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
@@ -687,7 +687,7 @@ func (ec *executionContext) _Query___schema(ctx context.Context, field graphql.C
 	return ec.marshalO__Schema2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐSchema(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) __Service_sdl(ctx context.Context, field graphql.CollectedField, obj *fedruntime.Service) (ret graphql.Marshaler) {
+func (ec *executionContext) __Service_sdl(ctx context.Context, field graphql.CollectedField, obj *fedruntime.GqlgenService) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
 			ec.Error(ctx, ec.Recover(ctx, r))
@@ -1810,7 +1810,7 @@ func (ec *executionContext) ___Type_ofType(ctx context.Context, field graphql.Co
 
 // region    ************************** interface.gotpl ***************************
 
-func (ec *executionContext) __Entity(ctx context.Context, sel ast.SelectionSet, obj fedruntime.Entity) graphql.Marshaler {
+func (ec *executionContext) __Entity(ctx context.Context, sel ast.SelectionSet, obj fedruntime.GqlgenEntity) graphql.Marshaler {
 	switch obj := (obj).(type) {
 	case nil:
 		return graphql.Null
@@ -1978,7 +1978,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 
 var _ServiceImplementors = []string{"_Service"}
 
-func (ec *executionContext) __Service(ctx context.Context, sel ast.SelectionSet, obj *fedruntime.Service) graphql.Marshaler {
+func (ec *executionContext) __Service(ctx context.Context, sel ast.SelectionSet, obj *fedruntime.GqlgenService) graphql.Marshaler {
 	fields := graphql.CollectFields(ec.OperationContext, sel, _ServiceImplementors)
 
 	out := graphql.NewFieldSet(fields)
@@ -2355,7 +2355,7 @@ func (ec *executionContext) marshalN_Any2ᚕmapᚄ(ctx context.Context, sel ast.
 	return ret
 }
 
-func (ec *executionContext) marshalN_Entity2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋfedruntimeᚐEntity(ctx context.Context, sel ast.SelectionSet, v []fedruntime.Entity) graphql.Marshaler {
+func (ec *executionContext) marshalN_Entity2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋfedruntimeᚐGqlgenEntity(ctx context.Context, sel ast.SelectionSet, v []fedruntime.GqlgenEntity) graphql.Marshaler {
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -2379,7 +2379,7 @@ func (ec *executionContext) marshalN_Entity2ᚕgithubᚗcomᚋ99designsᚋgqlgen
 			if !isLen1 {
 				defer wg.Done()
 			}
-			ret[i] = ec.marshalO_Entity2githubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋfedruntimeᚐEntity(ctx, sel, v[i])
+			ret[i] = ec.marshalO_Entity2githubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋfedruntimeᚐGqlgenEntity(ctx, sel, v[i])
 		}
 		if isLen1 {
 			f(i)
@@ -2407,7 +2407,7 @@ func (ec *executionContext) marshalN_FieldSet2string(ctx context.Context, sel as
 	return res
 }
 
-func (ec *executionContext) marshalN_Service2githubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋfedruntimeᚐService(ctx context.Context, sel ast.SelectionSet, v fedruntime.Service) graphql.Marshaler {
+func (ec *executionContext) marshalN_Service2githubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋfedruntimeᚐGqlgenService(ctx context.Context, sel ast.SelectionSet, v fedruntime.GqlgenService) graphql.Marshaler {
 	return ec.__Service(ctx, sel, &v)
 }
 
@@ -2750,7 +2750,7 @@ func (ec *executionContext) marshalOString2ᚖstring(ctx context.Context, sel as
 	return graphql.MarshalString(*v)
 }
 
-func (ec *executionContext) marshalO_Entity2githubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋfedruntimeᚐEntity(ctx context.Context, sel ast.SelectionSet, v fedruntime.Entity) graphql.Marshaler {
+func (ec *executionContext) marshalO_Entity2githubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋfedruntimeᚐGqlgenEntity(ctx context.Context, sel ast.SelectionSet, v fedruntime.GqlgenEntity) graphql.Marshaler {
 	if v == nil {
 		return graphql.Null
 	}

--- a/example/federation/products/graph/model/models_gen.go
+++ b/example/federation/products/graph/model/models_gen.go
@@ -8,4 +8,4 @@ type Product struct {
 	Price int    `json:"price"`
 }
 
-func (Product) IsEntity() {}
+func (Product) IsGqlgenEntity() {}

--- a/example/federation/reviews/graph/generated/federation.go
+++ b/example/federation/reviews/graph/generated/federation.go
@@ -11,9 +11,9 @@ import (
 	"github.com/99designs/gqlgen/plugin/federation/fedruntime"
 )
 
-func (ec *executionContext) __resolve__service(ctx context.Context) (fedruntime.Service, error) {
+func (ec *executionContext) __resolve__service(ctx context.Context) (fedruntime.GqlgenService, error) {
 	if ec.DisableIntrospection {
-		return fedruntime.Service{}, errors.New("federated introspection disabled")
+		return fedruntime.GqlgenService{}, errors.New("federated introspection disabled")
 	}
 
 	var sdl []string
@@ -25,13 +25,13 @@ func (ec *executionContext) __resolve__service(ctx context.Context) (fedruntime.
 		sdl = append(sdl, src.Input)
 	}
 
-	return fedruntime.Service{
+	return fedruntime.GqlgenService{
 		SDL: strings.Join(sdl, "\n"),
 	}, nil
 }
 
-func (ec *executionContext) __resolve_entities(ctx context.Context, representations []map[string]interface{}) ([]fedruntime.Entity, error) {
-	list := []fedruntime.Entity{}
+func (ec *executionContext) __resolve_entities(ctx context.Context, representations []map[string]interface{}) ([]fedruntime.GqlgenEntity, error) {
+	list := []fedruntime.GqlgenEntity{}
 	for _, rep := range representations {
 		typeName, ok := rep["__typename"].(string)
 		if !ok {

--- a/example/federation/reviews/graph/generated/generated.go
+++ b/example/federation/reviews/graph/generated/generated.go
@@ -72,7 +72,7 @@ type ComplexityRoot struct {
 		Reviews func(childComplexity int) int
 	}
 
-	Service struct {
+	GqlgenService struct {
 		SDL func(childComplexity int) int
 	}
 }
@@ -196,11 +196,11 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		return e.complexity.User.Reviews(childComplexity), true
 
 	case "_Service.sdl":
-		if e.complexity.Service.SDL == nil {
+		if e.complexity.GqlgenService.SDL == nil {
 			break
 		}
 
-		return e.complexity.Service.SDL(childComplexity), true
+		return e.complexity.GqlgenService.SDL(childComplexity), true
 
 	}
 	return 0, false
@@ -591,9 +591,9 @@ func (ec *executionContext) _Query__entities(ctx context.Context, field graphql.
 		}
 		return graphql.Null
 	}
-	res := resTmp.([]fedruntime.Entity)
+	res := resTmp.([]fedruntime.GqlgenEntity)
 	fc.Result = res
-	return ec.marshalN_Entity2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋfedruntimeᚐEntity(ctx, field.Selections, res)
+	return ec.marshalN_Entity2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋfedruntimeᚐGqlgenEntity(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Query__service(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
@@ -626,9 +626,9 @@ func (ec *executionContext) _Query__service(ctx context.Context, field graphql.C
 		}
 		return graphql.Null
 	}
-	res := resTmp.(fedruntime.Service)
+	res := resTmp.(fedruntime.GqlgenService)
 	fc.Result = res
-	return ec.marshalN_Service2githubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋfedruntimeᚐService(ctx, field.Selections, res)
+	return ec.marshalN_Service2githubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋfedruntimeᚐGqlgenService(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Query___type(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
@@ -874,7 +874,7 @@ func (ec *executionContext) _User_reviews(ctx context.Context, field graphql.Col
 	return ec.marshalOReview2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgenᚋexampleᚋfederationᚋreviewsᚋgraphᚋmodelᚐReview(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) __Service_sdl(ctx context.Context, field graphql.CollectedField, obj *fedruntime.Service) (ret graphql.Marshaler) {
+func (ec *executionContext) __Service_sdl(ctx context.Context, field graphql.CollectedField, obj *fedruntime.GqlgenService) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
 			ec.Error(ctx, ec.Recover(ctx, r))
@@ -1997,7 +1997,7 @@ func (ec *executionContext) ___Type_ofType(ctx context.Context, field graphql.Co
 
 // region    ************************** interface.gotpl ***************************
 
-func (ec *executionContext) __Entity(ctx context.Context, sel ast.SelectionSet, obj fedruntime.Entity) graphql.Marshaler {
+func (ec *executionContext) __Entity(ctx context.Context, sel ast.SelectionSet, obj fedruntime.GqlgenEntity) graphql.Marshaler {
 	switch obj := (obj).(type) {
 	case nil:
 		return graphql.Null
@@ -2251,7 +2251,7 @@ func (ec *executionContext) _User(ctx context.Context, sel ast.SelectionSet, obj
 
 var _ServiceImplementors = []string{"_Service"}
 
-func (ec *executionContext) __Service(ctx context.Context, sel ast.SelectionSet, obj *fedruntime.Service) graphql.Marshaler {
+func (ec *executionContext) __Service(ctx context.Context, sel ast.SelectionSet, obj *fedruntime.GqlgenService) graphql.Marshaler {
 	fields := graphql.CollectFields(ec.OperationContext, sel, _ServiceImplementors)
 
 	out := graphql.NewFieldSet(fields)
@@ -2642,7 +2642,7 @@ func (ec *executionContext) marshalN_Any2ᚕmapᚄ(ctx context.Context, sel ast.
 	return ret
 }
 
-func (ec *executionContext) marshalN_Entity2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋfedruntimeᚐEntity(ctx context.Context, sel ast.SelectionSet, v []fedruntime.Entity) graphql.Marshaler {
+func (ec *executionContext) marshalN_Entity2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋfedruntimeᚐGqlgenEntity(ctx context.Context, sel ast.SelectionSet, v []fedruntime.GqlgenEntity) graphql.Marshaler {
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -2666,7 +2666,7 @@ func (ec *executionContext) marshalN_Entity2ᚕgithubᚗcomᚋ99designsᚋgqlgen
 			if !isLen1 {
 				defer wg.Done()
 			}
-			ret[i] = ec.marshalO_Entity2githubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋfedruntimeᚐEntity(ctx, sel, v[i])
+			ret[i] = ec.marshalO_Entity2githubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋfedruntimeᚐGqlgenEntity(ctx, sel, v[i])
 		}
 		if isLen1 {
 			f(i)
@@ -2694,7 +2694,7 @@ func (ec *executionContext) marshalN_FieldSet2string(ctx context.Context, sel as
 	return res
 }
 
-func (ec *executionContext) marshalN_Service2githubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋfedruntimeᚐService(ctx context.Context, sel ast.SelectionSet, v fedruntime.Service) graphql.Marshaler {
+func (ec *executionContext) marshalN_Service2githubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋfedruntimeᚐGqlgenService(ctx context.Context, sel ast.SelectionSet, v fedruntime.GqlgenService) graphql.Marshaler {
 	return ec.__Service(ctx, sel, &v)
 }
 
@@ -3022,7 +3022,7 @@ func (ec *executionContext) marshalOString2ᚖstring(ctx context.Context, sel as
 	return graphql.MarshalString(*v)
 }
 
-func (ec *executionContext) marshalO_Entity2githubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋfedruntimeᚐEntity(ctx context.Context, sel ast.SelectionSet, v fedruntime.Entity) graphql.Marshaler {
+func (ec *executionContext) marshalO_Entity2githubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋfedruntimeᚐGqlgenEntity(ctx context.Context, sel ast.SelectionSet, v fedruntime.GqlgenEntity) graphql.Marshaler {
 	if v == nil {
 		return graphql.Null
 	}

--- a/example/federation/reviews/graph/model/models.go
+++ b/example/federation/reviews/graph/model/models.go
@@ -4,7 +4,7 @@ type Product struct {
 	Upc string `json:"upc"`
 }
 
-func (Product) IsEntity() {}
+func (Product) IsGqlgenEntity() {}
 
 type Review struct {
 	Body    string
@@ -16,4 +16,4 @@ type User struct {
 	ID string `json:"id"`
 }
 
-func (User) IsEntity() {}
+func (User) IsGqlgenEntity() {}

--- a/plugin/federation/federation.go
+++ b/plugin/federation/federation.go
@@ -33,17 +33,17 @@ func (f *federation) MutateConfig(cfg *config.Config) error {
 	builtins := config.TypeMap{
 		"_Service": {
 			Model: config.StringList{
-				"github.com/99designs/gqlgen/plugin/federation/fedruntime.Service",
+				"github.com/99designs/gqlgen/plugin/federation/fedruntime.GqlgenService",
 			},
 		},
 		"_Entity": {
 			Model: config.StringList{
-				"github.com/99designs/gqlgen/plugin/federation/fedruntime.Entity",
+				"github.com/99designs/gqlgen/plugin/federation/fedruntime.GqlgenEntity",
 			},
 		},
 		"Entity": {
 			Model: config.StringList{
-				"github.com/99designs/gqlgen/plugin/federation/fedruntime.Entity",
+				"github.com/99designs/gqlgen/plugin/federation/fedruntime.GqlgenEntity",
 			},
 		},
 		"_Any": {

--- a/plugin/federation/federation.gotpl
+++ b/plugin/federation/federation.gotpl
@@ -5,9 +5,9 @@
 
 {{ reserveImport "github.com/99designs/gqlgen/plugin/federation/fedruntime" }}
 
-func (ec *executionContext) __resolve__service(ctx context.Context) (fedruntime.Service, error) {
+func (ec *executionContext) __resolve__service(ctx context.Context) (fedruntime.GqlgenService, error) {
 	if ec.DisableIntrospection {
-		return fedruntime.Service{}, errors.New("federated introspection disabled")
+		return fedruntime.GqlgenService{}, errors.New("federated introspection disabled")
 	}
 
 	var sdl []string
@@ -19,14 +19,14 @@ func (ec *executionContext) __resolve__service(ctx context.Context) (fedruntime.
 		sdl = append(sdl, src.Input)
 	}
 
-	return fedruntime.Service{
+	return fedruntime.GqlgenService{
 		SDL: strings.Join(sdl, "\n"),
 	}, nil
 }
 
 {{if .Entities}}
-func (ec *executionContext) __resolve_entities(ctx context.Context, representations []map[string]interface{}) ([]fedruntime.Entity, error) {
-	list := []fedruntime.Entity{}
+func (ec *executionContext) __resolve_entities(ctx context.Context, representations []map[string]interface{}) ([]fedruntime.GqlgenEntity, error) {
+	list := []fedruntime.GqlgenEntity{}
 	for _, rep := range representations {
 		typeName, ok := rep["__typename"].(string)
 		if !ok {

--- a/plugin/federation/fedruntime/runtime.go
+++ b/plugin/federation/fedruntime/runtime.go
@@ -1,13 +1,13 @@
 package fedruntime
 
-// Service is the service object that the
+// GqlgenService is the service object that the
 // generated.go file will return for the _service
 // query
-type Service struct {
+type GqlgenService struct {
 	SDL string `json:"sdl"`
 }
 
 // Everything with a @key implements this
-type Entity interface {
-	IsEntity()
+type GqlgenEntity interface {
+	IsGqlgenEntity()
 }


### PR DESCRIPTION
[CARESERV-928](https://grandrounds.atlassian.net/browse/CARESERV-928)

In a federated apollog graph, there are two default types, `_service` and `_entity`. gqlgen codegen makes structs for both of these types to support federation. Due to the naming convention, `_service` becomes `struct Service`.

The problem is, if you have a type in your graph like `type Service`, gqlgen generates a **conflicting** struct `struct Service`, which conflicts with its internal struct. The fork of this library renames the "internal" struct to include Gqlgen so that it's very unlikely to conflict with an end user.

When I originally made this fork, I didn't test it, and it had a typo in the code. I'm re-doing the fork here. I've tested it in bobs by replacing the gqlgen in bobs with the commit in this PR in `go.mod`:

    github.com/99designs/gqlgen => github.com/ConsultingMD/gqlgen v0.13.1-0.20210630164423-08be9277af31

Then I ran 

> go mod tidy
> bazel run //:gazelle -- update-repos -from_file=go/go.mod -to_macro=go/go_dependencies/workspace.bzl%go_dependencies
> bazelisk run //:gazelle -- update

Then I verified I could codegen in bobs (it failed on the last bad fork):

```
cd ./claims_server/graph/ ; go run github.com/99designs/gqlgen ; cd -
cd ./accountidentity_server/app/handler/graph/ ; go run github.com/99designs/gqlgen ; cd -
```

If we make any additional updates to this fork, we should test it in the downstream consumer before merging the fork.